### PR TITLE
Update to a version possible to download

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -183,16 +183,16 @@
                     "type": "extra-data",
                     "filename": "spotify.deb",
                     "only-arches": ["x86_64"],
-                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_amd64.deb",
-                    "sha256": "7e5e90b7ae0d797ec3b9b7592d8e2253c773d5f7be90b7014f06f481f82bce1a",
+                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.69.336.g7edcc575-39_amd64.deb",
+                    "sha256": "ed0dc69f7e50879fcf7bd1bb67e33f08af0c17ebd7bb608ce4e7a143dec1022e",
                     "size": 90723508
                 },
                 {
                     "type": "extra-data",
                     "filename": "spotify.deb",
                     "only-arches": ["i386"],
-                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_i386.deb",
-                    "sha256": "cf1ce274475d2468cd93227dc32cff613cd5b2d682c18a7567568a96864d33b4",
+                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.69.336.g7edcc575-39_i386.deb",
+                    "sha256": "09f7d26f9a56fa91fcb7984c2c183b627f31cba1a3966c11e3262868fa656821",
                     "size": 95004956
                 }
             ]


### PR DESCRIPTION
The old version no longer being possible to download:

```
x10an14@x10-HomeDesktop ~ $ date && lsb_release -a && uname -a
Wed Dec 13 20:23:55 CET 2017
No LSB modules are available.
Distributor ID:	LinuxMint
Description:	Linux Mint 18.3 Sylvia
Release:	18.3
Codename:	sylvia
Linux x10-HomeDesktop 4.10.0-42-generic #46~16.04.1-Ubuntu SMP Mon Dec 4 15:57:59 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
x10an14@x10-HomeDesktop ~ $ flatpak install flathub com.spotify.Client stable
Installing: com.spotify.Client/x86_64/stable from flathub
[#=                  ] Downloading: 0 bytes/90,7 MB
error: While downloading https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_amd64.deb: Server returned status 404: Not Found
x10an14@x10-HomeDesktop ~ $ flatpak install flathub com.spotify.Client stable -v
XA: Opening system flatpak installation at path /var/lib/flatpak
XA: Updating dependent runtime runtime/org.freedesktop.Platform/x86_64/1.6
XA: Transaction: update flathub:runtime/org.freedesktop.Platform/x86_64/1.6[$old]
XA: No installations directory in /etc/flatpak/installations.d. Skipping
XA: Transaction: install/update flathub:runtime/org.freedesktop.Platform.GL.nvidia-384-90/x86_64/1.4[*]
XA: Transaction: install/update flathub:runtime/org.freedesktop.Platform.Locale/x86_64/1.6[/en]
XA: Transaction: install flathub:app/com.spotify.Client/x86_64/stable[*]
XA: Updating remote metadata for flathub
Installing: com.spotify.Client/x86_64/stable from flathub
XA: Loading https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_amd64.deb using libsoup
[#=                  ] Downloading: 0 bytes/90,7 MB
error: While downloading https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_amd64.deb: Server returned status 404: Not Found
x10an14@x10-HomeDesktop ~ $ curl https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.67.582.g19436fa3-28_amd64.deb
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
x10an14@x10-HomeDesktop ~ $ date
Wed Dec 13 20:24:50 CET 2017
x10an14@x10-HomeDesktop ~ $ 
```