### PR TITLE
Enclose description data with <p></p>

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -8,10 +8,10 @@
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://www.spotify.com</url>
   <description>
-    Access all of your favorite music, discover new songs, and share music online with your friends - all in one place. 
+    <p>Access all of your favorite music, discover new songs, and share music online with your friends - all in one place. 
     Create shared playlists or share individual songs with your Facebook friends with just a click of a button. 
     Follow your favorite artists or friends to know what they are listening to, and then save the songs to your own playlists. 
-    Spotify is the best way to have access to millions of songs, and all the latest hits.
+      Spotify is the best way to have access to millions of songs, and all the latest hits.</p>
   </description>
   <screenshots>
     <screenshot>


### PR DESCRIPTION
I saw you updated the Spotify appdata file to add the description but the webapp still says "No description available". I've investigated a little and the appstream.xml file provided by flatpak doesn't include the tag <description> for this app. 

I think this is because the description text you provided is not inside a <p> tag. Other apps have <description><p>This app blah blah...</p></description>