### PR TITLE
Update nss lib

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_32_RTM/src/nss-3.32.tar.gz",
-                    "sha256": "35c6f381cc96bb25e4f924469f6ba3e57b3a16e0c2fb7e295a284a00d57ed335"
+                    "url": "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_36_1_RTM/src/nss-3.36.1.tar.gz",
+                    "sha256": "6025441d528ff6a7f1a4b673b6ee7d3540731ada3f78d5acd5c3b3736b222bff"
                 },
                 {
                     "type": "patch",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -72,7 +72,7 @@
                 }
             ],
             "build-commands": [
-                "./build.sh --system-sqlite --system-nspr --enable-libpkix -v -o",
+                "./build.sh --system-sqlite --system-nspr --enable-libpkix --disable-tests -v -o",
                 "install -D ../dist/Release/lib/*.so /app/lib"
             ]
         },


### PR DESCRIPTION
Currently used nss is a year old. Newest nss successfully work with spotify on Archlinux.