### PR TITLE
Patch to work with freedesktop 18.08

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -1,11 +1,11 @@
 {
     "app-id": "com.spotify.Client",
-    "branch": "stable",
+    "branch": "18.08",
     /* Not actually Electron but shares many deps */
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
+    "base-version": "18.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "unstable",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "spotify",
     "separate-locales": false,

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -5,7 +5,7 @@
     "base": "io.atom.electron.BaseApp",
     "base-version": "stable",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "unstable",
     "sdk": "org.freedesktop.Sdk",
     "command": "spotify",
     "separate-locales": false,
@@ -128,7 +128,7 @@
                 "install spotify-bin /app/bin/spotify",
                 "install -Dm644 com.spotify.Client.appdata.xml /app/share/appdata/com.spotify.Client.appdata.xml",
                 "cp /usr/bin/ar /app/bin",
-                "cp /usr/lib/libbfd-*.so /app/lib"
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Freedesktop 18.08 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system.

Note: this is not backwards compatible with 1.6, as the file it moves (/usr/lib/{multiarch-triple}/libbfd.so) does not exist in the old runtime.