### PR TITLE
Allow passing arguments from launcher to spotify app

### DIFF
--- a/spotify-bin
+++ b/spotify-bin
@@ -2,7 +2,7 @@
 
 SCALE_FACTOR=`get-scale-factor.py`
 
-/app/extra/bin/spotify --force-device-scale-factor=$SCALE_FACTOR&
+/app/extra/bin/spotify --force-device-scale-factor=$SCALE_FACTOR "$@" &
 sleep 2 # TODO: Actually detect when window appears
 # Set dark variant
 xprop -f _GTK_THEME_VARIANT 8u -set _GTK_THEME_VARIANT dark -name Spotify


### PR DESCRIPTION
Spotify app accepts several arguments which are corectly passed from .dekstop file but ignored by shell script. This change pass them in shell script as well. Example:
`com.spotify.Client --show-console`