### PR TITLE
bump package version to 1.0.94.262.g3d5c231c-9

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,7 +40,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-    <release date="2018-10-25" version="1.0.92.390"/>
+    <release date="2018-12-03" version="1.0.94.262"/>
     <release date="2018-09-15" version="1.0.89.313"/>
   </releases>
   <update_contact>tingping_at_fedoraproject.org</update_contact>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -153,7 +153,7 @@
                     ],
                     "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.94.262.g3d5c231c-9_amd64.deb",
                     "sha256": "039443c918f44f853ef293b5804481b503ae5a5ec63e2bc670e7aecfb6c84f80",
-                    "size": 102410368
+                    "size": 104191924
                 },
                 {
                     "type": "extra-data",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -152,7 +152,7 @@
                         "x86_64"
                     ],
                     "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.94.262.g3d5c231c-9_amd64.deb",
-                    "sha256": "039443c918f44f853ef293b5804481b503ae5a5ec63e2bc670e7aecfb6c84f80",
+                    "sha256": "92803d614da2fd4802f801d85da9cf786f34216bbfa6085d5791c3e8350b4f44",
                     "size": 104191924
                 },
                 {

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -151,7 +151,7 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.92.390.g2ce5ec7d-18_amd64.deb",
+                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.0.94.262.g3d5c231c-9_amd64.deb",
                     "sha256": "039443c918f44f853ef293b5804481b503ae5a5ec63e2bc670e7aecfb6c84f80",
                     "size": 102410368
                 },


### PR DESCRIPTION
Issue: broken link