### PR TITLE
Bugfix Error 404 while fetching Spotify

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,6 +40,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release date="2019-04-30" version="1.1.5.153"/>
     <release date="2019-01-28" version="1.1.0.237"/>
     <release date="2019-01-28" version="1.0.98.78"/>
     <release date="2019-01-09" version="1.0.96.181"/>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -152,8 +152,8 @@
                         "x86_64"
                     ],
                     "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.5.153.gf614956d-16_amd64.deb",
-                    "sha256": "4b77c6baa59d5e8d8e6f800138fefdf579747cb81615b9711dfa25d6c2d5fa9f",
-                    "size": 104760412
+                    "sha256": "a7e189c430af1788c4f7d02ae411bfb38f0eccc5f829218d9dc81e1dab382037",
+                    "size": 113728674
                 },
                 {
                     "type": "extra-data",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -151,7 +151,7 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.0.237.g378f6f25-11_amd64.deb",
+                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.5.153.gf614956d-16_amd64.deb",
                     "sha256": "4b77c6baa59d5e8d8e6f800138fefdf579747cb81615b9711dfa25d6c2d5fa9f",
                     "size": 104760412
                 },


### PR DESCRIPTION
Spotify seems to change its url to fetch the client with every update. This bugfix worked for me.