### PR TITLE
Update ffmpeg to 3.2.14

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -84,8 +84,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ffmpeg.org/releases/ffmpeg-1.2.12.tar.bz2",
-                    "sha256": "913ac95c7fad92c2a4ebcfd11850904f531845c75d45c3e4e4a693990fe2497d"
+                    "url": "https://ffmpeg.org/releases/ffmpeg-3.2.14.tar.xz",
+                    "sha256": "a0047aa0215538a13d10da2fe48674af574e8e94b7ecf3071bdf1addb056be92"
                 }
             ]
         },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -1,6 +1,5 @@
 {
     "app-id": "com.spotify.Client",
-    "branch": "stable",
     "//": "Not actually Electron but shares many deps",
     "base": "io.atom.electron.BaseApp",
     "base-version": "18.08",


### PR DESCRIPTION
When looking inside official spotify deb you can see that it recommends libavcodec-extra57 as latest among few older alternatives. This translates to ffmpeg 3.2.14 in debian (https://packages.debian.org/stretch/libavcodec-extra57) which means we can safely update to it.

Also use xz archive which is slightly smaller.