### PR TITLE
Replace upstream .desktop file

### DIFF
--- a/com.spotify.Client.desktop
+++ b/com.spotify.Client.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Spotify
+GenericName=Online music streaming service
+Comment=Access all of your favorite music
+Icon=com.spotify.Client
+TryExec=spotify
+Exec=spotify %U
+Terminal=false
+MimeType=x-scheme-handler/spotify;
+Categories=Audio;Music;AudioVideo;
+Keywords=Music;Player;Streaming;Online;
+StartupWMClass=Spotify

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -113,6 +113,7 @@
                 "install -Dm644 com.spotify.Client.appdata.xml /app/share/appdata/com.spotify.Client.appdata.xml",
                 "install -Dm644 com.spotify.Client.svg /app/share/icons/hicolor/scalable/apps/com.spotify.Client.svg",
                 "install -Dm644 com.spotify.Client-symbolic.svg /app/share/icons/hicolor/symbolic/apps/com.spotify.Client-symbolic.svg",
+                "install -Dm644 com.spotify.Client.desktop /app/share/applications/com.spotify.Client.desktop",
                 "cp /usr/bin/ar /app/bin",
                 "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib",
                 "ARCH_TRIPLE=$(gcc --print-multiarch) && ln -s /usr/lib/${ARCH_TRIPLE}/libcurl.so.4.5.0 /app/lib/libcurl-gnutls.so.4"
@@ -128,11 +129,12 @@
                         "rm -f control.tar.gz data.tar.gz debian-binary",
                         "mv usr/* .",
                         "rmdir usr",
-                        "mkdir -p export/share/applications",
-                        "sed s/Icon=spotify-client/Icon=com.spotify.Client/ share/spotify/spotify.desktop > export/share/applications/com.spotify.Client.desktop",
-                        "echo StartupWMClass=Spotify >> export/share/applications/com.spotify.Client.desktop",
                         "rm -r share/spotify/apt-keys share/spotify/spotify.desktop share/spotify/icons share/doc"
                     ]
+                },
+                {
+                    "type": "file",
+                    "path": "com.spotify.Client.desktop"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
This commit adds com.spotify.Client.desktop and uses that for the base of the .desktop file instead of the upstream .desktop file.