### PR TITLE
Update to the latest version of FFmpeg

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -88,8 +88,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ffmpeg.org/releases/ffmpeg-3.2.14.tar.xz",
-                    "sha256": "a0047aa0215538a13d10da2fe48674af574e8e94b7ecf3071bdf1addb056be92"
+                    "url": "https://ffmpeg.org/releases/ffmpeg-4.2.1.tar.xz",
+                    "sha256": "cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4"
                 }
             ]
         },


### PR DESCRIPTION
The current version used is a couple years old.

This is still going to require some testing to make sure there are no issues with compatibility or regressions.