### PR TITLE
Update to the latest version of FFmpeg that will still play local files

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -88,8 +88,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ffmpeg.org/releases/ffmpeg-3.2.14.tar.xz",
-                    "sha256": "a0047aa0215538a13d10da2fe48674af574e8e94b7ecf3071bdf1addb056be92"
+                    "url": "https://ffmpeg.org/releases/ffmpeg-3.4.6.tar.xz",
+                    "sha256": "3572279cb139d9e39dcfbc23edf438ff5311ec3fc5d0dcb3558e49591e5cb83e"
                 }
             ]
         },


### PR DESCRIPTION
This is still going to require some testing to make sure there are no issues with compatibility or regressions.

Lets see how far up in the versions we can get before it breaks.