### PR TITLE
Switch to http source

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -164,7 +164,7 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.10.546.ge08ef575-19_amd64.deb",
+                    "url": "http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.10.546.ge08ef575-19_amd64.deb",
                     "sha256": "da49fd4d222ff7d719345fba6298f38a6422ef293bb43ada13cf857a694a12e6",
                     "size": 114975574
                 }

--- a/update-release.py
+++ b/update-release.py
@@ -8,8 +8,8 @@ import urllib.request
 
 from lxml import etree
 
-PACKAGE_URL = 'http://repository.spotify.com/dists/testing/non-free/binary-amd64/Packages'
-REPO_URL = 'https://repository-origin.spotify.com/'
+PACKAGE_URL = 'https://repository-origin.spotify.com/dists/testing/non-free/binary-amd64/Packages'
+REPO_URL = 'http://repository.spotify.com/'
 MANIFEST = 'com.spotify.Client.json'
 APPDATA = 'com.spotify.Client.appdata.xml'
 


### PR DESCRIPTION
https mirror is very unreliable recently so switch to http for the rescue.

Fixes https://github.com/flathub/com.spotify.Client/issues/108