### PR TITLE
Expose the app to Gnome's notification controls

### DIFF
--- a/com.spotify.Client.desktop
+++ b/com.spotify.Client.desktop
@@ -11,3 +11,4 @@ MimeType=x-scheme-handler/spotify;
 Categories=Audio;Music;AudioVideo;
 Keywords=Music;Player;Streaming;Online;
 StartupWMClass=Spotify
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Gnome provides a settings menu for permitting/disabling access to the notification daemon.
In order for an application to show up its application file needs to expose X-GNOME-UsesNotifications=true
This should get Spotify to show up in the notification settings under Gnome.
You can read more on this here: https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource