### PR TITLE
Add spotifywm to fix window class, icon, etc.

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -116,7 +116,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/dasJ/spotifywm.git",
-                    "commit": "91dd553"
+                    "commit": "91dd5532ffb7a398d775abe94fe7781904ab406f"
                 }
             ]
         },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -109,7 +109,7 @@
             "name": "spotifywm",
             "buildsystem": "simple",
             "build-commands": [
-                "make",
+                "make -j ${FLATPAK_BUILDER_N_JOBS:-1}",
                 "install -Dm644 spotifywm.so /app/lib/spotifywm.so"
             ],
             "sources": [

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -114,9 +114,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/dasJ/spotifywm/archive/master.zip",
-                    "sha256": "133ce3bd232bc2a683d9a80e8b640676b35cefa697eae6629b53f00e4196ecec"
+                    "type": "git",
+                    "url": "https://github.com/dasJ/spotifywm.git",
+                    "commit": "91dd553"
                 }
             ]
         },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -106,6 +106,21 @@
             ]
         },
         {
+            "name": "spotifywm",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "install -Dm644 spotifywm.so /app/lib/spotifywm.so"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/dasJ/spotifywm/archive/master.zip",
+                    "sha256": "133ce3bd232bc2a683d9a80e8b640676b35cefa697eae6629b53f00e4196ecec"
+                }
+            ]
+        },
+        {
             "name": "python3-XLib",
             "buildsystem": "simple",
             "build-commands": [

--- a/spotify-bin
+++ b/spotify-bin
@@ -37,7 +37,7 @@ if [ $URI_HANDLED -eq 0 ]; then
     exit 0
 fi
 
-env PULSE_PROP_application.icon_name="com.spotify.Client" /app/extra/bin/spotify --force-device-scale-factor=$SCALE_FACTOR "$@" &
+env PULSE_PROP_application.icon_name="com.spotify.Client" LD_PRELOAD=/app/lib/spotifywm.so /app/extra/bin/spotify --force-device-scale-factor=$SCALE_FACTOR "$@" &
 `set-dark-theme-variant.py` &
 
 if [ $URI_HANDLED -eq 1 ]; then


### PR DESCRIPTION
Baby's first flathub contribution! (In case it's unclear, I'm baby.)

I thought that my first attempt at adding spotifywm was gonna fall flat on its face and I was gonna have to spend a couple hours fixing something, but it... just seems to work, exactly as I thought it would. I put the preload library in /app/lib, hope that's the right place semantically.

When I first tried to work on this, I struggled with the server not really cooperating with letting me download the base package but I was able to complete the build process today and test it, and it seems to be working as expected. This should fix #68, or at the very least, make it better. :)