### PR TITLE
Update to 1.1.46.916.g416cacf1 and use snap as source

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -34,6 +34,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release date="2020-11-16" version="1.1.46.916.g416cacf1"/>
     <release date="2020-09-16" version="1.1.42.622"/>
     <release date="2020-02-19" version="1.1.26.501"/>
     <release date="2019-07-17" version="1.1.10.546"/>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -135,6 +135,21 @@
             ]
         },
         {
+            "name": "squashfs-tools",
+            "buildsystem": "simple",
+            "build-commands": [
+            "XZ_SUPPORT=1 make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=${FLATPAK_DEST}/bin"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/plougher/squashfs-tools.git",
+                    "tag": "4.4-git.1",
+                    "commit": "ddfb69d50971710502c9818a1fd1be42497e9808"
+                }
+            ]
+        },
+        {
             "name": "spotify",
             "buildsystem": "simple",
             "build-commands": [
@@ -145,8 +160,6 @@
                 "install -Dm644 com.spotify.Client.svg /app/share/icons/hicolor/scalable/apps/com.spotify.Client.svg",
                 "install -Dm644 com.spotify.Client-symbolic.svg /app/share/icons/hicolor/symbolic/apps/com.spotify.Client-symbolic.svg",
                 "install -Dm644 com.spotify.Client.desktop /app/share/applications/com.spotify.Client.desktop",
-                "cp /usr/bin/ar /app/bin",
-                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib",
                 "ARCH_TRIPLE=$(gcc --print-multiarch) && ln -s /usr/lib/${ARCH_TRIPLE}/libcurl.so.4 /app/lib/libcurl-gnutls.so.4"
             ],
             "sources": [
@@ -154,13 +167,13 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "ar x spotify.deb",
-                        "rm -f spotify.deb",
-                        "tar xf data.tar.gz",
-                        "rm -f control.tar.gz data.tar.gz debian-binary",
-                        "mv usr/* .",
-                        "rmdir usr",
-                        "rm -r share/spotify/apt-keys share/spotify/spotify.desktop share/spotify/icons share/doc"
+                        "unsquashfs -no-progress spotify.snap",
+                        "rm -f spotify.snap",
+                        "mkdir bin share",
+                        "mv squashfs-root/usr/bin/spotify bin/spotify",
+                        "mv squashfs-root/usr/share/spotify share/spotify",
+                        "rm -r squashfs-root",
+                        "rm -r share/spotify/apt-keys share/spotify/spotify.desktop share/spotify/icons"
                     ]
                 },
                 {
@@ -197,13 +210,18 @@
                 },
                 {
                     "type": "extra-data",
-                    "filename": "spotify.deb",
+                    "filename": "spotify.snap",
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.42.622.gbd112320-37_amd64.deb",
-                    "sha256": "101a3699197659b8bc60a4fd8b579e63cc494e7abd089c45306559329af4a868",
-                    "size": 126293582
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_43.snap",
+                    "sha256": "bc5eaee0a17b15d2a680c5b951bbc123b3c730b8c95f6c70311808fc894ccd28",
+                    "size": 181366784,
+                    "x-checker-data": {
+                        "type": "snapcraft",
+                        "name": "spotify",
+                        "channel": "stable"
+                        }
                 }
             ]
         }

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -44,14 +44,15 @@
             "config-opts": [
                 "-Dtests=false",
                 "-Dintrospection=disabled",
+                "-Dman=false",
                 "-Dgtk_doc=false",
                 "-Ddocbook_docs=disabled"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.8.tar.xz",
-                    "sha256": "69209e0b663776a00c7b6c0e560302a8dbf66b2551d55616304f240bba66e18c"
+                    "url": "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.9.tar.xz",
+                    "sha256": "66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
                 }
             ]
         },


### PR DESCRIPTION
Spotify stopped releasing new deb packages therefore this switches to snap as extra-data source which is considered acceptable elsewhere in flathub.

This also enables update-checker support for making future updates easier.

As a bonus this may fix issues with unreliable downloads from spotify cdn.

Fixes https://github.com/flathub/com.spotify.Client/issues/145