### PR TITLE
Add back xprop

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -103,6 +103,16 @@
             ]
         },
         {
+            "name": "xprop",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://xorg.freedesktop.org/archive/individual/app/xprop-1.2.5.tar.gz",
+                    "sha256": "b7bf6b6be6cf23e7966a153fc84d5901c14f01ee952fbd9d930aa48e2385d670"
+                }
+            ]
+        },
+        {
             "name": "python-setuptools_scm",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
This was removed by mistake in https://github.com/flathub/com.spotify.Client/commit/65b7c917a29ea43c150ada9838adf6a0653e1cb4

Fix #158 
