### PR TITLE
Remove x-checker-data for python modules

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -123,10 +123,6 @@
                     "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/57/38/930b1241372a9f266a7df2b184fb9d4f497c2cef2e016b014f82f541fe7c/setuptools_scm-6.0.1.tar.gz",
                     "sha256": "d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "setuptools_scm"
-                    }
                 }
             ]
         },
@@ -141,10 +137,6 @@
                     "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/40/9c/107e22f637d33434404c07d69112b9d26b76ee0dd4dd705131ab6cdcc818/python-xlib-0.31.tar.gz",
                     "sha256": "74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "python-xlib"
-                    }
                 }
             ]
         },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -122,7 +122,7 @@
                 {
                     "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/57/38/930b1241372a9f266a7df2b184fb9d4f497c2cef2e016b014f82f541fe7c/setuptools_scm-6.0.1.tar.gz",
-                    "sha256": "d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92",
+                    "sha256": "d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92"
                 }
             ]
         },
@@ -136,7 +136,7 @@
                 {
                     "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/40/9c/107e22f637d33434404c07d69112b9d26b76ee0dd4dd705131ab6cdcc818/python-xlib-0.31.tar.gz",
-                    "sha256": "74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9",
+                    "sha256": "74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9"
                 }
             ]
         },


### PR DESCRIPTION
The recent versions fail to build due to missing deps which make it impossible to build and test new spotify releases. Auto updates makes sense for something which is effortless to update otherwise this will block app updates as a whole.