### PR TITLE
pick lzo patches from #174

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -165,8 +165,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/plougher/squashfs-tools.git",
-                    "tag": "4.4-git.1",
-                    "commit": "ddfb69d50971710502c9818a1fd1be42497e9808"
+                    "tag": "4.5",
+                    "commit": "0496d7c3de3e09da37ba492081c86159806ebb07"
                 }
             ]
         },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -156,10 +156,30 @@
             ]
         },
         {
+            "name": "lzo",
+            "config-opts": [
+                "--enable-shared",
+                "--disable-static"
+            ],
+            "cleanup": [
+                "/include",
+                "/share/doc",
+                "*.la",
+                "/lib/*.so"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz",
+                    "sha256": "c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"
+                }
+            ]
+        },
+        {
             "name": "squashfs-tools",
             "buildsystem": "simple",
             "build-commands": [
-                "XZ_SUPPORT=1 make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=${FLATPAK_DEST}/bin"
+                "XZ_SUPPORT=1 LZO_SUPPORT=1 make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=${FLATPAK_DEST}/bin"
             ],
             "sources": [
                 {


### PR DESCRIPTION
#174 added lzo support to unsquashfs as snaps now use this, it was superseded by #175 but the lzo patches were not picked up. Add the lzo patches so the Flatpak is installable once more. Fixes #176. Thanks to @Erick555 