### PR TITLE
Fix title bar coming up empty

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -174,7 +174,7 @@
                         "mv squashfs-root/usr/bin/spotify bin/spotify",
                         "mv squashfs-root/usr/share/spotify share/spotify",
                         "rm -r squashfs-root",
-                        "rm -r share/spotify/apt-keys share/spotify/spotify.desktop share/spotify/icons"
+                        "rm -r share/spotify/apt-keys share/spotify/spotify.desktop"
                     ]
                 },
                 {


### PR DESCRIPTION
For some reason, when the icons folder is missing, the title bar comes up empty. 

I don't know why, but this fixes the issue.

This resolves #184 

Edit: I think this also resolves #180 and #179. I didn't mention them previously because I didn't notice them before I made the change.