### PR TITLE
Remove Notification sandbox hole

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -15,7 +15,6 @@
         "--share=network",
         "--device=dri",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-        "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.gnome.SessionManager",
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",


### PR DESCRIPTION
starting with libnotify 0.8 all calls go through the portal instead.