### PR TITLE
Silent install

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -217,11 +217,10 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "unsquashfs -quiet -no-progress spotify.snap",
+                        "unsquashfs -quiet -no-progress spotify.snap usr/bin usr/share/spotify",
                         "rm -f spotify.snap",
                         "mkdir bin share",
-                        "mv squashfs-root/usr/bin/spotify bin/spotify",
-                        "mv squashfs-root/usr/share/spotify share/spotify",
+                        "mv squashfs-root/usr/{bin,share} .",
                         "rm -r squashfs-root",
                         "rm -r share/spotify/apt-keys share/spotify/spotify.desktop",
                         "patchelf --replace-needed libcurl-gnutls.so.4 libcurl.so.4 bin/spotify"

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -218,11 +218,8 @@
                     "dest-filename": "apply_extra",
                     "commands": [
                         "unsquashfs -quiet -no-progress spotify.snap usr/bin usr/share/spotify",
-                        "rm -f spotify.snap",
-                        "mkdir bin share",
-                        "mv squashfs-root/usr/{bin,share} .",
-                        "rm -r squashfs-root",
-                        "rm -r share/spotify/apt-keys share/spotify/spotify.desktop",
+                        "mv squashfs-root/usr/* .",
+                        "rm -r spotify.snap squashfs-root share/spotify/apt-keys share/spotify/spotify.desktop",
                         "patchelf --replace-needed libcurl-gnutls.so.4 libcurl.so.4 bin/spotify"
                     ]
                 },

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -217,7 +217,7 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "unsquashfs -no-progress spotify.snap",
+                        "unsquashfs -quiet -no-progress spotify.snap",
                         "rm -f spotify.snap",
                         "mkdir bin share",
                         "mv squashfs-root/usr/bin/spotify bin/spotify",


### PR DESCRIPTION
Hello,

Currently `apply_extra` is not silent when performing the unsquashfs, as I undestand this is not desirable by flatpak conventions.

1. The first commit in this PR is to add the `-quiet` flag so that installs don't break the cli output of flatpak.

2. Next I also simplified the `apply_extra` process so that it only extract the required files from the `.snap` file (so `usr/lib` is not extracted and deleted).

3. Finally unified/simplified all `mv`/`rm` commands into one of each.

I tested it locally and the final `extra` folder contents and structure is exactly the same as is currently being, but faster and quieter.

In case that only the first part, or the first 2 parts are desired, tell me so I can remove the changes not desired from this PR.
