### PR TITLE
Update spotify.snap to 1.2.22.982.g794acc0a

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -38,6 +38,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release version="1.2.22.982.g794acc0a" date="2023-10-16"/>
     <release version="1.2.13.661.ga588f749" date="2023-09-08"/>
     <release version="1.2.11.916.geb595a67" date="2023-05-15"/>
     <release version="1.2.9.743.g85d9593d" date="2023-04-19"/>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -305,9 +305,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_68.snap",
-                    "sha256": "51b0341c72c29c434eddeddcfb039eb89f45f5dd7d4b930043acc4836862b709",
-                    "size": 166240256,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_70.snap",
+                    "sha256": "cf99f6d2dc130d07134672d67484dc25a74a9927345462978b72c0b2efb29a05",
+                    "size": 175001600,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -4,6 +4,9 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
     "command": "spotify",
     "separate-locales": false,
     "tags": [
@@ -17,12 +20,17 @@
         "--device=dri",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--talk-name=org.gnome.SessionManager",
+        "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
         "--env=LD_LIBRARY_PATH=/app/lib",
         "--env=TMPDIR=/tmp"
     ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/vala/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/vala/lib"
+    },
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
@@ -158,6 +166,98 @@
                         "project-id": 1868,
                         "stable-only": false,
                         "url-template": "http://www.oberhumer.com/opensource/lzo/download/lzo-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libayatana-appindicator",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DENABLE_BINDINGS_MONO=NO",
+                "-DENABLE_BINDINGS_VALA=NO"
+            ],
+            "modules": [
+                "shared-modules/intltool/intltool-0.51.json",
+                {
+                    "name": "libdbusmenu-gtk3",
+                    "buildsystem": "autotools",
+                    "build-options": {
+                        "cflags": "-Wno-error",
+                        "env": {
+                            "HAVE_VALGRIND_FALSE": "#",
+                            "HAVE_VALGRIND_TRUE": ""
+                        }
+                    },
+                    "config-opts": [
+                        "--with-gtk=3",
+                        "--disable-dumper",
+                        "--disable-static",
+                        "--disable-tests",
+                        "--disable-gtk-doc",
+                        "--enable-introspection=no",
+                        "--disable-vala"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
+                            "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+                        }
+                    ],
+                    "cleanup": [
+                        "/include",
+                        "/libexec",
+                        "/lib/pkgconfig",
+                        "/lib/*.la",
+                        "/share/doc",
+                        "/share/libdbusmenu",
+                        "/share/gtk-doc",
+                        "/share/gir-1.0"
+                    ]
+                },
+                {
+                    "name": "ayatana-ido",
+                    "buildsystem": "cmake-ninja",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/AyatanaIndicators/ayatana-ido.git",
+                            "tag": "0.10.1",
+                            "commit": "13402a2cc4616b4b5f4244413599e635fcfc1401",
+                            "x-checker-data": {
+                                "type": "git",
+                                "tag-pattern": "^([\\d.]+)$"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "libayatana-indicator",
+                    "buildsystem": "cmake-ninja",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/AyatanaIndicators/libayatana-indicator.git",
+                            "tag": "0.9.3",
+                            "commit": "a62e8ca13040554a8fc2536ce7e6aa888c5729d9",
+                            "x-checker-data": {
+                                "type": "git",
+                                "tag-pattern": "^([\\d.]+)$"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/libayatana-appindicator.git",
+                    "tag": "0.5.92",
+                    "commit": "d214fe3e7a6b1ba8faea68d70586310b34dc643c",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
                     }
                 }
             ]


### PR DESCRIPTION
This PR takes the commit from #259 and cherry-picks https://github.com/eclipseo/com.spotify.Client/commit/f0b705d509a3ab863d9da3c8c20da253c88d8014 with removed references to beta/edge - leaving what's (most likely) necessary to get the appindicator support. 

The build from flathubbot now works for me. I can also tell that the MPRIS support on Wayland must be much better - I've tested this with KDE Connect's "Pause media during calls". It works wonders - pauses Spotify when the call is incoming and starts it back again when the call is finished. 