### PR TITLE
Update runtime to 23.08 & ffmpeg patch

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.spotify.Client",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "spotify",
     "separate-locales": false,
@@ -310,7 +310,8 @@
                 "--enable-decoder=mp3",
                 "--enable-decoder=mp3adu",
                 "--enable-decoder=opus",
-                "--enable-decoder=vorbis"
+                "--enable-decoder=vorbis",
+                "--disable-inline-asm"
             ],
             "sources": [
                 {

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -310,8 +310,7 @@
                 "--enable-decoder=mp3",
                 "--enable-decoder=mp3adu",
                 "--enable-decoder=opus",
-                "--enable-decoder=vorbis",
-                "--disable-inline-asm"
+                "--enable-decoder=vorbis"
             ],
             "sources": [
                 {
@@ -327,6 +326,10 @@
                         },
                         "url-template": "https://ffmpeg.org/releases/ffmpeg-$version.tar.xz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "ffmpeg-binutils-2.41.patch"
                 }
             ]
         },

--- a/ffmpeg-binutils-2.41.patch
+++ b/ffmpeg-binutils-2.41.patch
@@ -1,0 +1,74 @@
+From cc703cf60759d9798f440a9417e4efa2fcbe2747 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+(cherry picked from commit effadce6c756247ea8bae32dc13bb3e6f464f0eb)
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed1983..ca7e2dffc107 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 


### PR DESCRIPTION
Updating to 23.08 results in the ffmpeg build to fail. 

So looking at https://github.com/flathub/org.blender.Blender/pull/154 adding the build option "--disable-inline-asm" did build ffmpeg successfully. 

After testing Local Files Playback, everything seems to be working fine.