### PR TITLE
Workaround: Create "spotify" directory in $XDG_CONFIG_HOME

### DIFF
--- a/spotify-bin
+++ b/spotify-bin
@@ -26,6 +26,11 @@ function waitandopenuri {
     fi
 }
 
+# Create a "spotify" directory in $XDG_CONFIG_HOME.
+# This works around an app bug where proxy settings don't persist when
+# launching the app for the first time. See issue #280 for more context.
+mkdir -p "${XDG_CONFIG_HOME}/spotify"
+
 openuri "$@"
 URI_HANDLED=$?
 # If URI_HANDLED = 0, We raised an existing instance.


### PR DESCRIPTION
This workaround is only necessary to make proxy settings persist when users are not logged in (i.e., when they launch the app for the first time).

See issue #280 for more context on this.

Closes #280