### PR TITLE
Set XCURSOR_PATH for running Spotify under Wayland

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -21,7 +21,8 @@
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
         "--env=LD_LIBRARY_PATH=/app/lib",
-        "--env=TMPDIR=/tmp"
+        "--env=TMPDIR=/tmp",
+        "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
Seemingly not a problem on KDE, but cursor is still small on GNOME hosts.

Fixes: #306