### PR TITLE
Use the lzo module from the runtime

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -37,7 +37,6 @@
         "*.a"
     ],
     "modules": [
-        "shared-modules/lzo/lzo.json",
         "shared-modules/squashfs-tools/squashfs-tools.json",
         "shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json",
         {


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides the lzo module. 

Fixes: https://github.com/flathub/com.spotify.Client/issues/348