### PR TITLE
Add org.freedesktop.ScreenSaver Session Bus talk permission

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -14,6 +14,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=dri",
+        "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.kde.StatusNotifierWatcher",


### PR DESCRIPTION
Update `com.spotify.Client.json` to include `org.freedesktop.ScreenSaver` Session Bus talk permission.  
This allows Spotify to inhibit the screensaver when it enters fullscreen.

Spotify uses `org.freedesktop.ScreenSaver` as a fallback when `org.gnome.SessionManager` is not available.
The current configuration only enables talk access to `org.gnome.SessionManager`, so screensaver inhibition works only on GNOME.