### PR TITLE
Fix tray icon

### DIFF
--- a/spotify-preload.c
+++ b/spotify-preload.c
@@ -55,7 +55,7 @@ void *app_indicator_new_with_path (const char *id, const char *icon_name, int ca
 {
     ensure_resolved();
 
-    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, icon_theme_path);
+    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, NULL);
 }
 
 void app_indicator_set_icon (void *indicator, const char *icon_name)


### PR DESCRIPTION
This was a regression in #359, we don't want to use the paths Spotify wants to and instead want the default paths.

Closes #361