### PR TITLE
Update beta branch to use snap build 1.2.86.502.g8cd7fb22

### DIFF
--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,6 +40,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release version="1.2.86.502.g8cd7fb22" date="2026-04-07"/>
     <release version="1.2.84.475.ga1a748ff" date="2026-03-09"/>
     <release version="1.2.82.428.g0ac8be2b" date="2026-02-09"/>
     <release version="1.2.74.477.g3be53afe" date="2025-11-19"/>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -151,9 +151,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_93.snap",
-                    "sha256": "298dad8db2089468878f599a00ceff964d7ede3a27898aaa2763623986f86c4b",
-                    "size": 170369024,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_94.snap",
+                    "sha256": "5e1c3268e6dc93abe222f0d15c4ced9522e36b97ec7f0e4780751443331e84b2",
+                    "size": 170303488,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",


### PR DESCRIPTION
## Summary

- Supports new edge build `1.2.86.502.g8cd7fb22`, uploaded by the Spotify devs to Snapcraft on 2026-04-07.

### Testing
- `git submodule update --init --recursive`
- `flatpak install flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08` (may need running if not already installed)
- `flatpak-builder --user --install --force-clean build-dir com.spotify.Client.json`
- `flatpak run --branch=beta com.spotify.Client`

#### My Test Environments

1. System 1
   - OS: Fedora 43
   - DE: GNOME 49
   - Architecture: x86_64

2. System 2
   - OS: Fedora 43
   - DE: KDE Plasma 6.6
   - Architecture: x86_64

<img width="2560" height="1396" alt="Screenshot_20260407_110345-obfuscated" src="https://github.com/user-attachments/assets/b54bed48-5daa-4b98-a3e2-1ceca38874f7" />
