### PR TITLE
Update beta branch to use snap build 1.2.90.451.gb094aab0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package runs Wayland by default; an X11 fallback is in place for X11 enviro
 
 ```sh
 flatpak override --user --socket=x11 com.spotify.Client
-env WAYLAND_DISPLAY= flatpak run --branch=beta com.spotify.Client --ozone-platform=x11 --disable-features=UseOzonePlatform
+env WAYLAND_DISPLAY= flatpak run com.spotify.Client --ozone-platform=x11 --disable-features=UseOzonePlatform
 ```
 
 To go back to the default behaviour:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Spotify
 
+### Reporting bugs
+
+This is community flatpak packaging of official spotify binaries. Please report issues only specifically related to flatpak. Issues reproducible on other platforms can be reported directly in [upstream](https://community.spotify.com/t5/Desktop-Linux/bd-p/desktop_linux).
+
 ### Making flags persistent
 
 Below is an example spotify-flags.conf file that defines the flags --disable-gpu-shader-disk-cache:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@ To go back to the default behaviour:
 ```sh
 flatpak override --user --reset com.spotify.Client
 ```
+
+### Pipewire and Pulseaudio
+
+Recent Spotify versions use pipewire audio output by default, on older systems pipewire daemon may be not available. In order to switch back to pulseaudio daemon, specify appropriate flag during one-time launch:
+
+```sh
+flatpak run com.spotify.Client --audio-api=pulseaudio
+```
+
+In order to make it persistent, write the option into config file described in #### Making flags persistent:
+```
+~/.var/app/com.spotify.Client/config/spotify-flags.conf
+
+# This line will be ignored.
+--audio-api=pulseaudio
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package runs Wayland by default; an X11 fallback is in place for X11 enviro
 
 ```sh
 flatpak override --user --socket=x11 com.spotify.Client
-env WAYLAND_DISPLAY= flatpak run com.spotify.Client --ozone-platform=x11 --disable-features=UseOzonePlatform
+env WAYLAND_DISPLAY= flatpak run --branch=beta com.spotify.Client --ozone-platform=x11 --disable-features=UseOzonePlatform
 ```
 
 To go back to the default behaviour:
@@ -35,7 +35,7 @@ flatpak override --user --reset com.spotify.Client
 Recent Spotify versions use pipewire audio output by default, on older systems pipewire daemon may be not available. In order to switch back to pulseaudio daemon, specify appropriate flag during one-time launch:
 
 ```sh
-flatpak run com.spotify.Client --audio-api=pulseaudio
+flatpak run --branch=beta com.spotify.Client --audio-api=pulseaudio
 ```
 
 In order to make it persistent, write the option into config file described in #### Making flags persistent:

--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,8 +40,11 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-    <release version="1.2.82.428.g0ac8be2b" date="2026-02-20">
+    <release version="1.2.84.475.ga1a748ff" date="2026-04-07">
       <description></description>
+    </release>
+    <release version="1.2.82.428.g0ac8be2b" date="2026-02-20">
+      <description/>
     </release>
     <release version="1.2.74.477.g3be53afe" date="2025-11-19"/>
     <release version="1.2.63.394.g126b0d89" date="2025-06-30"/>

--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,20 +40,11 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-
-    <release version="1.2.89.539.gfb3c63a3" date="2026-05-22">
-      <description></description>
-    </release>
-    <release version="1.2.86.502.g8cd7fb22" date="2026-05-18">
-      <description/>
-    </release>
-    <release version="1.2.84.475.ga1a748ff" date="2026-04-07">
-      <description/>
-    </release>
-    <release version="1.2.82.428.g0ac8be2b" date="2026-02-20">
-      <description/>
-    </release>
-
+    <release version="1.2.90.451.gb094aab0" date="2026-05-22"/>
+    <release version="1.2.89.539.gfb3c63a3" date="2026-05-11"/>
+    <release version="1.2.86.502.g8cd7fb22" date="2026-04-07"/>
+    <release version="1.2.84.475.ga1a748ff" date="2026-03-09"/>
+    <release version="1.2.82.428.g0ac8be2b" date="2026-02-09"/>
     <release version="1.2.74.477.g3be53afe" date="2025-11-19"/>
     <release version="1.2.63.394.g126b0d89" date="2025-06-30"/>
     <release version="1.2.60.564.gcc6305cb" date="2025-05-19"/>

--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,8 +40,11 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-    <release version="1.2.86.502.g8cd7fb22" date="2026-05-18">
+    <release version="1.2.89.539.gfb3c63a3" date="2026-05-22">
       <description></description>
+    </release>
+    <release version="1.2.86.502.g8cd7fb22" date="2026-05-18">
+      <description/>
     </release>
     <release version="1.2.84.475.ga1a748ff" date="2026-04-07">
       <description/>

--- a/com.spotify.Client.appdata.xml
+++ b/com.spotify.Client.appdata.xml
@@ -40,8 +40,11 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-    <release version="1.2.84.475.ga1a748ff" date="2026-04-07">
+    <release version="1.2.86.502.g8cd7fb22" date="2026-05-18">
       <description></description>
+    </release>
+    <release version="1.2.84.475.ga1a748ff" date="2026-04-07">
+      <description/>
     </release>
     <release version="1.2.82.428.g0ac8be2b" date="2026-02-20">
       <description/>

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -150,9 +150,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_92.snap",
-                    "sha256": "a4cfdb3f19af623ef51057623b3fd67459c58f24f727538a83d6e4bdf3212f8e",
-                    "size": 169017344,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_93.snap",
+                    "sha256": "298dad8db2089468878f599a00ceff964d7ede3a27898aaa2763623986f86c4b",
+                    "size": 170369024,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -22,6 +22,7 @@
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--env=LD_LIBRARY_PATH=/app/lib",
         "--env=TMPDIR=/tmp",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -150,9 +150,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_94.snap",
-                    "sha256": "5e1c3268e6dc93abe222f0d15c4ced9522e36b97ec7f0e4780751443331e84b2",
-                    "size": 170303488,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_95.snap",
+                    "sha256": "28b21c2ea44e359d3f5411c70524528d1b056830f090db86f7b56d0fbc41ff33",
+                    "size": 184176640,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -3,6 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
+    "default-branch": "beta",
     "command": "spotify",
     "separate-locales": false,
     "tags": [
@@ -150,9 +151,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_95.snap",
-                    "sha256": "28b21c2ea44e359d3f5411c70524528d1b056830f090db86f7b56d0fbc41ff33",
-                    "size": 184176640,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_96.snap",
+                    "sha256": "ba61ec4d0e5cffbbc2fccfe7e419b024e5f4a5f46380399b3522e1109f6b3c96",
+                    "size": 183676928,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",
@@ -162,6 +163,5 @@
                 }
             ]
         }
-    ],
-    "default-branch": "beta"
+    ]
 }

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -17,7 +17,6 @@
         "--device=dri",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-        "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -75,8 +75,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.xz",
-                    "sha256": "2290461f467c08ab801731ed412d8e724a5511d6c33173654bd9c1d2e25d0617",
+                    "url": "https://ffmpeg.org/releases/ffmpeg-4.4.7.tar.xz",
+                    "sha256": "39e7d6d0af050a0a8aae737d610d77264e67b9657f3a346f72bba03312565e2a",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 5405,
@@ -150,9 +150,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_93.snap",
-                    "sha256": "298dad8db2089468878f599a00ceff964d7ede3a27898aaa2763623986f86c4b",
-                    "size": 170369024,
+                    "url": "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_94.snap",
+                    "sha256": "5e1c3268e6dc93abe222f0d15c4ced9522e36b97ec7f0e4780751443331e84b2",
+                    "size": 170303488,
                     "x-checker-data": {
                         "type": "snapcraft",
                         "name": "spotify",

--- a/spotify-preload.c
+++ b/spotify-preload.c
@@ -55,7 +55,7 @@ void *app_indicator_new_with_path (const char *id, const char *icon_name, int ca
 {
     ensure_resolved();
 
-    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, icon_theme_path);
+    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, NULL);
 }
 
 void app_indicator_set_icon (void *indicator, const char *icon_name)

--- a/spotify-preload.c
+++ b/spotify-preload.c
@@ -2,7 +2,9 @@
 
 #define _GNU_SOURCE
 #include <stdlib.h>
+#include <stdio.h>
 #include <dlfcn.h>
+#include <pthread.h>
 
 static const char *ICON_NAME_OVERRIDE = "com.spotify.Client-symbolic";
 
@@ -13,34 +15,59 @@ static void (*original_set_icon) (void *, const char *);
 static void* (*original_indicator_new) (const char *, const char *, int);
 static void* (*original_indicator_new_with_path) (const char *, const char *, int, const char*);
 
+
+static pthread_once_t resolve_once = PTHREAD_ONCE_INIT;
+
+static void resolve_symbols (void)
+{
+    original_set_icon_full = dlsym (RTLD_NEXT, "app_indicator_set_icon_full");
+
+    original_set_icon = dlsym (RTLD_NEXT, "app_indicator_set_icon");
+
+    original_indicator_new = dlsym (RTLD_NEXT, "app_indicator_new");
+
+    original_indicator_new_with_path = dlsym (RTLD_NEXT, "app_indicator_new_with_path");
+
+    if (!original_set_icon_full ||
+        !original_set_icon ||
+        !original_indicator_new ||
+        !original_indicator_new_with_path)
+    {
+        fprintf(stderr, "[spotify-icon-override] failed to resolve symbols\n");
+        abort();
+    }
+}
+
+static inline void ensure_resolved (void)
+{
+    pthread_once (&resolve_once, resolve_symbols);
+}
+
+
 void *app_indicator_new (const char *id, const char *icon_name, int category)
 {
-    if (!original_indicator_new)
-        original_indicator_new = dlsym (RTLD_NEXT, "app_indicator_new");
+    ensure_resolved();
 
     return original_indicator_new (id, ICON_NAME_OVERRIDE, category);
 }
 
 void *app_indicator_new_with_path (const char *id, const char *icon_name, int category, const char *icon_theme_path)
 {
-    if (!original_indicator_new_with_path)
-        original_indicator_new_with_path = dlsym (RTLD_NEXT, "app_indicator_new_with_path");
+    ensure_resolved();
 
-    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, NULL);
+    return original_indicator_new_with_path (id, ICON_NAME_OVERRIDE, category, icon_theme_path);
 }
 
 void app_indicator_set_icon (void *indicator, const char *icon_name)
 {
-    if (!original_set_icon)
-        original_set_icon = dlsym (RTLD_NEXT, "app_indicator_set_icon");
+    ensure_resolved();
 
     original_set_icon (indicator, ICON_NAME_OVERRIDE);
 }
 
 void app_indicator_set_icon_full (void *indicator, const char *icon_name, const char *icon_desc)
 {
-    if (!original_set_icon_full)
-        original_set_icon_full = dlsym (RTLD_NEXT, "app_indicator_set_icon_full");
+    ensure_resolved();
 
     original_set_icon_full (indicator, ICON_NAME_OVERRIDE, icon_desc);
 }


### PR DESCRIPTION
## Summary

- Supports new edge build `1.2.90.451.gb094aab0`, uploaded by the Spotify devs to Snapcraft on 2026-05-22.

### Testing
- `git submodule update --init --recursive`
- `flatpak install flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08` (may need running if not already installed)
- `flatpak-builder --user --install --force-clean build-dir com.spotify.Client.json`
- `flatpak run --branch=beta com.spotify.Client`

#### My Test Environments

1. System 1
   - OS: Fedora 44
   - DE: GNOME 50
   - Architecture: x86_64

2. System 2
   - OS: Fedora 44
   - DE: KDE Plasma 6.6
   - Architecture: x86_64

<img width="1920" height="1200" alt="Screenshot From 2026-05-26 22-06-33-obfuscated" src="https://github.com/user-attachments/assets/65d08f96-45c8-4cb0-8e33-a1c0ab2873b0" />

