### PR TITLE
fix: remove PipeWire socket to restore audio on many existing Linux systems

### DIFF
--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -21,7 +21,6 @@
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
-        "--filesystem=xdg-run/pipewire-0",
         "--env=LD_LIBRARY_PATH=/app/lib",
         "--env=TMPDIR=/tmp",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -13,6 +13,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
+        "--socket=pipewire",
         "--share=network",
         "--device=dri",
         "--talk-name=org.freedesktop.ScreenSaver",

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -13,7 +13,6 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--socket=pipewire",
         "--share=network",
         "--device=dri",
         "--talk-name=org.freedesktop.ScreenSaver",
@@ -22,6 +21,7 @@
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
+        "--filesystem=xdg-run/pipewire-0",
         "--env=LD_LIBRARY_PATH=/app/lib",
         "--env=TMPDIR=/tmp",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"

--- a/com.spotify.Client.json
+++ b/com.spotify.Client.json
@@ -22,7 +22,6 @@
         "--own-name=org.mpris.MediaPlayer2.spotify",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-pictures:ro",
-        "--filesystem=xdg-run/pipewire-0:ro",
         "--env=LD_LIBRARY_PATH=/app/lib",
         "--env=TMPDIR=/tmp",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"


### PR DESCRIPTION
Fixes #383

## Problem

Commit `9b26fc9` (PR #380, May 2026) added `--filesystem=xdg-run/pipewire-0:ro` to the manifest with the rationale "Spotify uses pipewire by default now."

This causes silent audio failure on systems where PipeWire is installed but not serving audio (e.g. Ubuntu 22.04). Spotify's CEF (Chromium 146) detects the PipeWire socket in the sandbox, selects PipeWire as its audio backend, and commits — there is no fallback to PulseAudio. On systems where PipeWire is not the audio server, the result is no audio with no error message.

## Why removing the line is the correct fix

Spotify does not need direct PipeWire socket access. Audio playback works through `--socket=pulseaudio`, which is already in the manifest:

- On **PipeWire systems with `pipewire-pulse`** (Fedora, Bazzite, Arch with `pipewire-audio`, most modern desktops): `pipewire-pulse` intercepts PulseAudio connections and routes them through PipeWire natively. Full PipeWire audio, zero configuration.
- On **PulseAudio systems** (Ubuntu 22.04, older distros): connects to PulseAudio directly.

This works because `--socket=pulseaudio` connects to whatever is listening on the PulseAudio socket — whether that's actual PulseAudio or PipeWire's PulseAudio compatibility layer. No detection, no fallback logic needed.

**Note:** `pipewire-pulse` is not a dependency of `pipewire` on any major distro — it's a separate optional package. Systems like Ubuntu 22.04 ship PipeWire for screen sharing (xdg-desktop-portal) but use PulseAudio for audio, with no `pipewire-pulse` installed. Exposing the PipeWire socket on these systems is what causes CEF to select the wrong audio backend.

## How other Flatpak apps handle this

| App | `--socket=pulseaudio` | PipeWire socket | Notes |
|-----|----------------------|-----------------|-------|
| Firefox | Yes | **No** | PulseAudio only — PipeWire handled via `pipewire-pulse` |
| Slack | Yes | **No** | Same approach |
| Signal | Yes | **No** | Same approach |
| Teams | Yes | **No** | Same approach |
| Discord | Yes | `xdg-run/pipewire-0` (r/w) | Added by Discord engineer for **Steam Deck screen sharing** ([DiscordCanary#682](https://github.com/flathub/com.discordapp.DiscordCanary/pull/682)), not for audio |
| **Spotify** | Yes | `xdg-run/pipewire-0:ro` | No screen sharing — socket serves no purpose |

Discord is the only other app that exposes the PipeWire socket, and it does so for a specific non-audio feature (screen capture in Steam Deck game mode) requested by a Discord engineer. Spotify has no equivalent use case.

## Why not just drop `:ro`?

Initial testing on Bazzite 44 (PipeWire 1.6.6) showed no audio with `:ro`, and audio worked after overriding to read-write. However, after reverting to the stock `:ro` manifest and rebooting, audio worked again — the failure was not reproducible.

This is consistent with how Unix sockets work: `connect()`, `send()`, and `recv()` bypass the filesystem mount's read-only flag. The `:ro` restricts file creation/deletion in the mount path, not socket communication. The initial failure was likely a transient PipeWire session issue, not caused by `:ro` itself.

The real problem is **exposing the socket at all**, which causes CEF to select PipeWire as the audio backend on systems where PipeWire is present but not serving audio (e.g. Ubuntu 22.04). Dropping `:ro` does not fix that.

## Tradeoff: compatibility over direct PipeWire

This change means CEF will use the PulseAudio API on **all** systems, including modern PipeWire desktops. The audio path on those systems becomes:

```
Spotify → PulseAudio API → pipewire-pulse → PipeWire → hardware
```

Instead of the direct path available when the PipeWire socket is exposed:

```
Spotify → PipeWire API → PipeWire → hardware
```

For a music player streaming 44.1kHz audio, the practical difference is negligible — `pipewire-pulse` is a thin translation layer, not a full server. Latency, sample rates, and format negotiation all pass through fine.

We favour compatibility here: silent audio failure with no error message on Ubuntu 22.04 LTS (supported until 2027) and similar systems is worse than an imperceptible extra hop on modern desktops.

**When Flatpak adds `--socket=pipewire` support**, the manifest should declare both `--socket=pulseaudio` and `--socket=pipewire` — that would give CEF proper access on modern systems while still falling back gracefully. As of Flatpak 1.17.7, `pipewire` is not a valid socket type.


## Workaround (for users on current version)

```bash
mkdir -p ~/.var/app/com.spotify.Client/config
echo "--audio-api=pulseaudio" > ~/.var/app/com.spotify.Client/config/spotify-flags.conf
```

This forces CEF to skip PipeWire and use PulseAudio directly. Remove after this fix is released.
